### PR TITLE
replace container-fluid with container

### DIFF
--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -32,7 +32,7 @@
     
     {
       title: "Revamped Grid System",
-      description: "Look for <code>spanX</code> non-form containers and replace with <code>col-lg-X</code> <code>col-md-X</code> <code>col-sm-X</code> (leaving mobile to collapse into a single column). Change <code>row-fluid</code> to <code>row</code> since they are now the same. Remove <code>container-fluid</code> since it is now a noop.",
+      description: "Look for <code>spanX</code> non-form containers and replace with <code>col-lg-X</code> <code>col-md-X</code> <code>col-sm-X</code> (leaving mobile to collapse into a single column). Change <code>row-fluid</code> to <code>row</code> since they are now the same. Since <code>container-fluid</code> is now a noop, replace it with <code>container</code>.",
       run: function(doc) {
         var count = 0;
         

--- a/src/upgrader.js
+++ b/src/upgrader.js
@@ -69,7 +69,7 @@
         $fluidContainers = $(doc).find(".container-fluid")
         if ($fluidContainers.length > 0) {
           count += $fluidContainers.length;
-          $fluidRows.removeClass('container-fluid');
+          $fluidContainers.removeClass('container-fluid').addClass('container');
         }
         
         return (count > 0) ? count + " Replaced" : false;


### PR DESCRIPTION
Noticed "container-fluid" wasn't getting removed as intended. Additionally, I'd suggest instead of being removed, it should actually be replaced with "container". From what I can tell "container-fluid" was used instead of (not in addition to) "container" in Bootstrap 2.x and Bootstrap 3 still uses "container". Hope this helps!
